### PR TITLE
[API-2092] Fixes an issue where ESLint was taking forever to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ dist
 
 # Mac files
 .DS_STORE
+
+# Test builds
+dist-test/

--- a/packages/rollup-plugin-web-workers/.gitignore
+++ b/packages/rollup-plugin-web-workers/.gitignore
@@ -1,1 +1,0 @@
-dist-test/


### PR DESCRIPTION
## Summary

The `dist-test` dir was being linted which was causing ESLint to hang.

https://vertexvis.atlassian.net/browse/API-2092